### PR TITLE
Fix womenwhogo.org link

### DIFF
--- a/starting-a-chapter.md
+++ b/starting-a-chapter.md
@@ -1,4 +1,4 @@
-# How to Start a [Women Who Go](womenwhogo.org) Chapter
+# How to Start a [Women Who Go](https://womenwhogo.org) Chapter
 
 
 *NOTE: You must identfy as a woman or gender minority to start a chapter*


### PR DESCRIPTION
I noticed the "Women Who Go" link at https://github.com/womenwhogo/wikis/blob/master/starting-a-chapter.md is broken.